### PR TITLE
Change the parameter order for `xdotool`

### DIFF
--- a/bemoji
+++ b/bemoji
@@ -156,7 +156,7 @@ _typer() {
     elif [ -n "$WAYLAND_DISPLAY" ] && command -v wtype >/dev/null 2>&1; then
         wtype -s 30 "$totype"
     elif [ -n "$DISPLAY" ] && command -v xdotool >/dev/null 2>&1; then
-        xdotool type "$totype" --delay 30
+        xdotool --delay 30 type "$totype"
     else
         printf "No suitable typing tool found."
         exit 1

--- a/bemoji
+++ b/bemoji
@@ -156,7 +156,7 @@ _typer() {
     elif [ -n "$WAYLAND_DISPLAY" ] && command -v wtype >/dev/null 2>&1; then
         wtype -s 30 "$totype"
     elif [ -n "$DISPLAY" ] && command -v xdotool >/dev/null 2>&1; then
-        xdotool --delay 30 type "$totype"
+        xdotool type --delay 30 "$totype"
     else
         printf "No suitable typing tool found."
         exit 1


### PR DESCRIPTION
Hi Marty!

This is a simple fix to prevent `xdotool` from typing the following string: `--delay30`:

![image](https://user-images.githubusercontent.com/5663277/148228304-9c321218-9ac5-466e-bde5-8265f7038d07.png)
![image](https://user-images.githubusercontent.com/5663277/148228449-1bb8499a-3980-4d15-a7ea-656ecb3910c2.png)
