### PR TITLE
✨ Add -n option to prevent newline after emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- ### Added -->
+### Added
+
+- Add new option `-n` which suppresses printing the final newline character in output
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To display *only* the emoji list passed in, pass an extra `-P` flag to bemoji.
 
 The path can also be a weblink which bemoji will download and use:
 
-```
+```bash
 bemoji -f "https://raw.githubusercontent.com/jchook/emoji-menu/master/data/emojis.txt"
 ```
 
@@ -189,6 +189,22 @@ Other valid options for this setting are `emoji`, `math`, `none`.
 
 If set to `none` and no files are in the emoji directory,
 bemoji will simply complain and not show anything.
+
+### Do not skip to new line after output
+
+By default, bemoji will craft the final output using a typical `echo` call for anything it prints directly.
+
+That means, it will also contain a final newline character.
+So, for example it would technically output `🦊\n` for the `fox` emoji,
+which skips to a new line in most circumstances.
+
+If you wish to prevent this character in the final output, use:
+
+```bash
+bemoji -n
+```
+
+Using this option will suppress the newline character and *only* print `🦊` as its output.
 
 ### Using a custom tool for picking, clipping, typing
 
@@ -234,6 +250,7 @@ BEMOJI_CLIP_CMD=wl-copy # which clipboard tool to use
 BEMOJI_TYPE_CMD=wtype # which typing tool to use (ydotool will NOT work)
 BEMOJI_PRIVATE_MODE=false # whether to save new entries
 BEMOJI_IGNORE_RECENT=false # whether to display recent entries
+BEMOJI_ECHO_NEWLINE=true # whether to end the output with a newline character
 ```
 
 ## 🤗 Issues

--- a/bemoji
+++ b/bemoji
@@ -13,6 +13,8 @@ bm_history_file="${bm_cache_dir}/bemoji-history.txt"
 # Command to run after user chooses an emoji
 bm_default_cmd="$BEMOJI_DEFAULT_CMD"
 
+# Newline after echo
+bm_echo_newline=${BEMOJI_ECHO_NEWLINE:-true}
 # Do not save choices
 bm_private_mode=${BEMOJI_PRIVATE_MODE:-false}
 # Do not sort results
@@ -31,6 +33,7 @@ usage() {
     echo "   -e             Only echo out the picked emoji."
     echo ""
     echo " Other options:"
+    echo "   -n             No newline after the picked emoji."
     echo "   -p             Do not save picked emoji to recent history."
     echo "   -P             Do not order emoji by recently used."
     echo "   -D <choice>    Choose specific default lists to download if none found locally."
@@ -48,12 +51,13 @@ version() {
 }
 
 # Get Options
-while getopts ":f:D:tcepPhv" o; do
+while getopts ":f:D:tcenpPhv" o; do
     case "${o}" in
     f) BEMOJI_CUSTOM_LIST="${OPTARG}" ;;
     t) bm_cmds+=(_typer) ;;
     c) bm_cmds+=(_clipper) ;;
     e) bm_cmds+=(cat) ;;
+    n) bm_echo_newline=false;;
     D) BEMOJI_DOWNLOAD_LIST="${OPTARG}" ;;
     p) bm_private_mode=true ;;
     P) bm_ignore_recent=true ;;
@@ -209,7 +213,8 @@ case "$exit_value" in
         bm_cmds+=(_clipper)
     fi
     for cmd in "${bm_cmds[@]}"; do
-        echo "$result" | "$cmd"
+        [ "$bm_echo_newline" = true ] && echo_opts= || echo_opts=-n
+        echo $echo_opts "$result" | "$cmd"
     done
     ;;
 10)

--- a/bemoji
+++ b/bemoji
@@ -33,7 +33,7 @@ usage() {
     echo "   -e             Only echo out the picked emoji."
     echo ""
     echo " Other options:"
-    echo "   -n             No newline after the picked emoji."
+    echo "   -n             Do not print a newline after the picked emoji."
     echo "   -p             Do not save picked emoji to recent history."
     echo "   -P             Do not order emoji by recently used."
     echo "   -D <choice>    Choose specific default lists to download if none found locally."

--- a/test/bemoji_cmds.bats
+++ b/test/bemoji_cmds.bats
@@ -63,3 +63,15 @@ typing result"
     BEMOJI_DEFAULT_CMD="echo my custom command" BEMOJI_CLIP_CMD="echo my clipping" run bemoji -c 3>&-
     assert_output "my clipping"
 }
+
+@test "Prints output with newline by default" {
+    bats_require_minimum_version 1.5.0
+    BEMOJI_PICKER_CMD="echo heart" run --keep-empty-lines -- bemoji -e
+    assert_output --regexp '^heart\n$'
+}
+
+@test "Prints output without newline on -n option" {
+    bats_require_minimum_version 1.5.0
+    BEMOJI_PICKER_CMD="echo heart" run --keep-empty-lines -- bemoji -ne
+    assert_output --regexp '^heart$'
+}


### PR DESCRIPTION
This Merge Request add the `bemoji -n` option to not include a newline character after the selected emoji.

A newline after the emoji might or might not be wanted, which this option the user can choose. 

In my case I don't want the newline as pasting it into `xfce4-terminal` a warning is shown whenever pasting something with newlines in it.