### PR TITLE
🩹 Let rofi match case insensitively as well

### DIFF
--- a/bemoji
+++ b/bemoji
@@ -180,7 +180,7 @@ _picker() {
     elif command -v wofi >/dev/null 2>&1; then
         wofi -p 🔍 -i --show dmenu
     elif command -v rofi >/dev/null 2>&1; then
-        rofi -p 🔍 -dmenu --kb-custom-1 "Alt+1" --kb-custom-2 "Alt+2"
+        rofi -p 🔍 -i -dmenu --kb-custom-1 "Alt+1" --kb-custom-2 "Alt+2"
     elif command -v dmenu >/dev/null 2>&1; then
         dmenu -p 🔍 -i -l 20
     else


### PR DESCRIPTION
For some reason, when using `rofi` as picker, the matching was performed case-sensitively although all other pickers were given the `-i` option. This Pull Request adds `-i` to `rofi` as well.