### PR TITLE
✨ Add support for fuzzel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add default support for `fuzzel` wayland-native picker tool
 - Add default support for `ilia` gtk-based picker tool, used by default in Regolith Linux
 - Pass through return code 1 from selection tool
 - (!) Number of displayed recent emoji can be set with `-P` option:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Will remember your favorite emojis and give you quick access.
 
 ### Dependencies
 
-* One of `bemenu`, `wofi`, `rofi`, `dmenu`, or supplying your own picker.
+* One of `bemenu`, `wofi`, `rofi`, `dmenu`, `ilia`, `fuzzel` or supplying your own picker.
 * One of `wl-copy`, `xclip`, `xsel` or supplying your own clipboard tool.
 * One of `wtype`, `xdotool` or supplying your own typing tool.
 * `sed`, `grep`, `cut`, `sort`, `uniq`, `tr`, `curl` if using the download functionality.

--- a/bemoji
+++ b/bemoji
@@ -26,6 +26,7 @@ declare -A default_pickers=(
 	["rofi"]="rofi -p 🔍 -i -dmenu --kb-custom-1 "Alt+1" --kb-custom-2 "Alt+2""
 	["dmenu"]="dmenu -p 🔍 -i -l 20"
 	["ilia"]="ilia -n -p textlist -l 'Emoji' -i desktop-magnifier"
+	["fuzzel"]="fuzzel -d"
 )
 
 # Report usage

--- a/bemoji
+++ b/bemoji
@@ -26,7 +26,7 @@ declare -A default_pickers=(
 	["rofi"]="rofi -p 🔍 -i -dmenu --kb-custom-1 "Alt+1" --kb-custom-2 "Alt+2""
 	["dmenu"]="dmenu -p 🔍 -i -l 20"
 	["ilia"]="ilia -n -p textlist -l 'Emoji' -i desktop-magnifier"
-	["fuzzel"]="fuzzel -d"
+	["fuzzel"]="fuzzel -d -p 🔍"
 )
 
 # Report usage


### PR DESCRIPTION
[Fuzzel](https://codeberg.org/dnkl/fuzzel) is a desktop executor for wayland, juste like wofi or rofi.
This PR simply adds `fuzzel` to the default pickers.

Though I wasn't able to make fuzzel use the correct `"🔍 "` prompt :(

`BEMOJI_PICKER_CMD='fuzzel -p "🔍 " -d' bemoji` produces the following:
![image](https://github.com/marty-oehme/bemoji/assets/21087104/ff2bff5b-0226-4c39-a3b6-2420ff6aa071)

`BEMOJI_PICKER_CMD='fuzzel -p 🔍 -d' bemoji` cannot be used as fuzzel requires the whitespace to be inside the prompt.

`fuzzel -p "🔍 "` also works fine:
![image](https://github.com/marty-oehme/bemoji/assets/21087104/a2735d20-482f-49d1-a57c-da0dd7c41e05)


Thanks for your consideration!